### PR TITLE
Force adding files in source-directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
         # FYI: filename with leading dot (.) or underscore (_) would be ignored by Jekyll,
         # which Github Pages depends on. So we use a normal filename here.
         date > ${{ inputs.source-directory}}/publish_date.txt
-        git add -A
+        git add --force ${{ inputs.source-directory }}
         git commit -m "Automated publish"
 
     - name: Push the build output to github pages


### PR DESCRIPTION
@julianfortune, I almost missed [your comment on a closed message](https://github.com/rayluo/github-pages-overwriter/issues/2#issuecomment-1364337152).

> For some reason in this run, GPO deleted my gh-pages branch, which ended up deleting the website and any associated github pages configuration

> Perhaps my .gitignore ignoring the build site's build directory is causing the issue?

And your suggestion sounds promising. Would you mind testing this fix and let me know if it works?

    uses: rayluo/github-pages-overwriter@force-add